### PR TITLE
Set up Zola static site generator for Rust rewrite

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -1,0 +1,48 @@
+name: Deploy to GitHub Pages
+
+on:
+  push:
+    branches:
+      - main
+  workflow_dispatch:
+
+permissions:
+  contents: read
+  pages: write
+  id-token: write
+
+concurrency:
+  group: "pages"
+  cancel-in-progress: false
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Install Zola
+        run: |
+          ZOLA_VERSION="0.19.1"
+          curl -sL https://github.com/getzola/zola/releases/download/v${ZOLA_VERSION}/zola-v${ZOLA_VERSION}-x86_64-unknown-linux-gnu.tar.gz | tar zxv
+          sudo mv zola /usr/local/bin/
+
+      - name: Build site
+        run: zola build
+
+      - name: Upload artifact
+        uses: actions/upload-pages-artifact@v3
+        with:
+          path: ./public
+
+  deploy:
+    environment:
+      name: github-pages
+      url: ${{ steps.deployment.outputs.page_url }}
+    runs-on: ubuntu-latest
+    needs: build
+    steps:
+      - name: Deploy to GitHub Pages
+        id: deployment
+        uses: actions/deploy-pages@v4

--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,13 @@
+# Zola build output
+public/
+
+# IDE
+.idea/
+.vscode/
+*.swp
+*.swo
+*~
+
+# OS
+.DS_Store
+Thumbs.db

--- a/README.md
+++ b/README.md
@@ -1,3 +1,95 @@
 # liam-thompson
 
-    A personal website
+A personal website built with [Zola](https://www.getzola.org/), a fast static site generator written in Rust.
+
+## Why Zola?
+
+- **Type-safe and memory-safe**: Written in Rust, providing compile-time guarantees
+- **Fast**: Builds the entire site in milliseconds
+- **Single binary**: No dependencies to install
+- **Built-in features**: Sass compilation, syntax highlighting, and more
+
+## Local Development
+
+### Prerequisites
+
+Install Zola:
+
+```bash
+# macOS
+brew install zola
+
+# Linux
+snap install zola --edge
+
+# Or download from https://github.com/getzola/zola/releases
+```
+
+### Running locally
+
+```bash
+# Start the development server
+zola serve
+
+# Site will be available at http://127.0.0.1:1111
+```
+
+The development server supports live reloading - changes to content, templates, or styles will automatically refresh your browser.
+
+### Building for production
+
+```bash
+# Build the site
+zola build
+
+# Output will be in the ./public directory
+```
+
+## Project Structure
+
+```
+.
+├── config.toml          # Site configuration
+├── content/             # Markdown content files
+│   ├── _index.md       # Homepage
+│   └── docs.md         # Docs page
+├── templates/           # HTML templates
+│   ├── base.html       # Base template
+│   ├── index.html      # Homepage template
+│   └── page.html       # Page template
+├── static/              # Static assets (CSS, images, etc.)
+│   └── style.css
+└── public/              # Generated site (git-ignored)
+```
+
+## Adding Content
+
+Create a new markdown file in the `content/` directory:
+
+```markdown
++++
+title = "My New Page"
+description = "Page description"
++++
+
+# Content goes here
+
+Write your content in markdown format.
+```
+
+## Deployment
+
+This site automatically deploys to GitHub Pages when changes are pushed to the `main` branch. The deployment is handled by GitHub Actions (see `.github/workflows/deploy.yml`).
+
+Site URL: https://leemthompo.github.io/liam-thompson/
+
+## Contributing
+
+1. Make your changes
+2. Test locally with `zola serve`
+3. Submit a pull request
+
+## Learn More
+
+- [Zola Documentation](https://www.getzola.org/documentation/)
+- [Tera Template Documentation](https://tera.netlify.app/docs/) (templating engine used by Zola)

--- a/config.toml
+++ b/config.toml
@@ -1,0 +1,28 @@
+# Zola configuration file for liam-thompson personal website
+
+base_url = "https://leemthompo.github.io/liam-thompson"
+title = "Liam Thompson"
+description = "A personal website"
+
+# The site theme to use.
+theme = ""
+
+# The default language; used in feeds
+default_language = "en"
+
+# Whether to automatically compile all Sass files in the sass directory
+compile_sass = true
+
+# Whether to build a search index to be used later on by a JavaScript library
+build_search_index = false
+
+# Whether to generate a feed file for the site
+generate_feed = false
+
+[markdown]
+# Whether to do syntax highlighting
+highlight_code = true
+highlight_theme = "base16-ocean-dark"
+
+[extra]
+# Put all your custom variables here

--- a/content/_index.md
+++ b/content/_index.md
@@ -1,0 +1,8 @@
++++
+title = "Liam Thompson"
+description = "A personal website"
++++
+
+# liam-thompson
+
+A personal website

--- a/content/docs.md
+++ b/content/docs.md
@@ -1,0 +1,8 @@
++++
+title = "Documentation"
+description = "Another page on this website"
++++
+
+## Another page on this website
+
+Different content, that deserves its own page, will live here.

--- a/static/style.css
+++ b/static/style.css
@@ -1,0 +1,139 @@
+/* Reset and base styles */
+* {
+    margin: 0;
+    padding: 0;
+    box-sizing: border-box;
+}
+
+body {
+    font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, 'Helvetica Neue', Arial, sans-serif;
+    line-height: 1.6;
+    color: #333;
+    background-color: #f9f9f9;
+}
+
+/* Navigation */
+nav {
+    background-color: #2c3e50;
+    padding: 1rem 0;
+    box-shadow: 0 2px 4px rgba(0,0,0,0.1);
+}
+
+.nav-container {
+    max-width: 1200px;
+    margin: 0 auto;
+    padding: 0 2rem;
+    display: flex;
+    justify-content: space-between;
+    align-items: center;
+}
+
+.nav-title {
+    color: #fff;
+    font-size: 1.5rem;
+    font-weight: bold;
+    text-decoration: none;
+}
+
+.nav-links {
+    list-style: none;
+    display: flex;
+    gap: 2rem;
+}
+
+.nav-links a {
+    color: #ecf0f1;
+    text-decoration: none;
+    transition: color 0.3s;
+}
+
+.nav-links a:hover {
+    color: #3498db;
+}
+
+/* Main content */
+main {
+    min-height: calc(100vh - 200px);
+    padding: 3rem 0;
+}
+
+.container {
+    max-width: 1200px;
+    margin: 0 auto;
+    padding: 0 2rem;
+}
+
+/* Typography */
+h1 {
+    font-size: 2.5rem;
+    margin-bottom: 1rem;
+    color: #2c3e50;
+}
+
+h2 {
+    font-size: 2rem;
+    margin-top: 2rem;
+    margin-bottom: 1rem;
+    color: #34495e;
+}
+
+p {
+    margin-bottom: 1rem;
+}
+
+/* Article/Page content */
+article {
+    background-color: #fff;
+    padding: 2rem;
+    border-radius: 8px;
+    box-shadow: 0 2px 8px rgba(0,0,0,0.1);
+}
+
+.homepage {
+    background-color: #fff;
+    padding: 2rem;
+    border-radius: 8px;
+    box-shadow: 0 2px 8px rgba(0,0,0,0.1);
+}
+
+/* Footer */
+footer {
+    background-color: #2c3e50;
+    color: #ecf0f1;
+    padding: 2rem 0;
+    text-align: center;
+    margin-top: 4rem;
+}
+
+footer a {
+    color: #3498db;
+    text-decoration: none;
+}
+
+footer a:hover {
+    text-decoration: underline;
+}
+
+/* Responsive design */
+@media (max-width: 768px) {
+    .nav-container {
+        flex-direction: column;
+        gap: 1rem;
+    }
+
+    .nav-links {
+        gap: 1rem;
+    }
+
+    h1 {
+        font-size: 2rem;
+    }
+
+    h2 {
+        font-size: 1.5rem;
+    }
+
+    .container {
+        padding: 0 1rem;
+    }
+}

--- a/templates/base.html
+++ b/templates/base.html
@@ -1,0 +1,33 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>{% block title %}{{ config.title }}{% endblock %}</title>
+    <meta name="description" content="{% block description %}{{ config.description }}{% endblock %}">
+    <link rel="stylesheet" href="{{ get_url(path='style.css') }}">
+</head>
+<body>
+    <nav>
+        <div class="nav-container">
+            <a href="{{ get_url(path='/') }}" class="nav-title">{{ config.title }}</a>
+            <ul class="nav-links">
+                <li><a href="{{ get_url(path='/') }}">Home</a></li>
+                <li><a href="{{ get_url(path='/docs') }}">Docs</a></li>
+            </ul>
+        </div>
+    </nav>
+
+    <main>
+        <div class="container">
+            {% block content %}{% endblock %}
+        </div>
+    </main>
+
+    <footer>
+        <div class="container">
+            <p>Built with <a href="https://www.getzola.org/">Zola</a> - A fast static site generator in Rust</p>
+        </div>
+    </footer>
+</body>
+</html>

--- a/templates/index.html
+++ b/templates/index.html
@@ -1,0 +1,11 @@
+{% extends "base.html" %}
+
+{% block title %}{{ section.title }} - {{ config.title }}{% endblock %}
+
+{% block description %}{{ section.description }}{% endblock %}
+
+{% block content %}
+<div class="homepage">
+    {{ section.content | safe }}
+</div>
+{% endblock %}

--- a/templates/page.html
+++ b/templates/page.html
@@ -1,0 +1,12 @@
+{% extends "base.html" %}
+
+{% block title %}{{ page.title }} - {{ config.title }}{% endblock %}
+
+{% block description %}{{ page.description }}{% endblock %}
+
+{% block content %}
+<article>
+    <h1>{{ page.title }}</h1>
+    {{ page.content | safe }}
+</article>
+{% endblock %}


### PR DESCRIPTION
## Summary

Hey @leemthompo! This implements the Rust rewrite (#1) using Zola, a static site generator written in Rust. This approach is much simpler than building a custom web server while still getting all the Rust benefits you wanted.

### What's included

✅ **Zola project structure** - Complete setup with config, content, templates, and static files  
✅ **Content migration** - Existing pages converted to Zola format with front matter  
✅ **Responsive templates** - Clean HTML templates with navigation between pages  
✅ **Modern styling** - Mobile-friendly CSS with a professional look  
✅ **GitHub Pages deployment** - Automatic deployment via GitHub Actions on push to main  
✅ **Comprehensive docs** - Updated README with setup, development, and deployment instructions  

### How to test

1. Install Zola: `brew install zola` (or see [releases](https://github.com/getzola/zola/releases))
2. Run `zola serve`
3. Visit http://127.0.0.1:1111

### Deployment

Once merged, the GitHub Actions workflow will automatically build and deploy the site to GitHub Pages. You may need to enable GitHub Pages in the repository settings (Settings → Pages → Source: GitHub Actions).

### Tickets

Closes #12 (Set up Zola project structure)  
Addresses #13, #14, #15 partially (content, templates, deployment)

Part of #1 (Rust rewrite)

---

🤖 Generated with [Claude Code](https://claude.com/claude-code)